### PR TITLE
Split clone_repo into create_branch role

### DIFF
--- a/one_platform.yaml
+++ b/one_platform.yaml
@@ -9,6 +9,7 @@
   loop:
   - scaffold_local_directories
   - clone_repo
+  - create_branch
   - scaffold_collection
   - clear_dest_directories
   - migrate_content

--- a/roles/clone_repo/tasks/main.yaml
+++ b/roles/clone_repo/tasks/main.yaml
@@ -8,6 +8,3 @@
   git:
     repo: "https://github.com/ansible-network/ansible_collections.{{ collection_namespace }}.{{ platform }}.git"
     dest: "{{ collection_parent }}"
-
-- name: Create a new branch
-  shell: "cd {{ collection_parent }} && git checkout -t -b {{ ansible_sha }}"

--- a/roles/create_branch/tasks/main.yaml
+++ b/roles/create_branch/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: Create a new branch
+  shell: "cd {{ collection_parent }} && git checkout -t -b {{ ansible_sha }}"


### PR DESCRIPTION
With migration to zuul, we don't actually want to git clone anything
however we do want to create a new branch. For now, just split this role
into another, and make it 2 step process.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>