### PR TITLE
Split commit_repo into push_repo role

### DIFF
--- a/one_platform.yaml
+++ b/one_platform.yaml
@@ -16,5 +16,6 @@
   - network_integration_tests
   - reformat_code
   - commit_repo
+  - push_repo
   loop_control:
     loop_var: role

--- a/roles/commit_repo/tasks/main.yaml
+++ b/roles/commit_repo/tasks/main.yaml
@@ -7,13 +7,3 @@
   shell: "git commit --allow-empty -m 'based on ansible/ansible {{ ansible_sha }}'"
   args:
     chdir: "{{ collection_parent }}"
-
-- name: Push the repo
-  shell: "git push origin"
-  args:
-    chdir: "{{ collection_parent }}"
-
-- name: Issue PR
-  shell: "hub pull-request -m 'based on ansible/ansible {{ ansible_sha }}'"
-  args:
-    chdir: "{{ collection_parent }}"

--- a/roles/push_repo/tasks/main.yaml
+++ b/roles/push_repo/tasks/main.yaml
@@ -1,0 +1,9 @@
+- name: Push the repo
+  shell: "git push origin"
+  args:
+    chdir: "{{ collection_parent }}"
+
+- name: Issue PR
+  shell: "hub pull-request -m 'based on ansible/ansible {{ ansible_sha }}'"
+  args:
+    chdir: "{{ collection_parent }}"

--- a/site-new.yaml
+++ b/site-new.yaml
@@ -19,5 +19,6 @@
       - migrate_content
       - network_integration_tests
       - reformat_code
+      - commit_repo
       loop_control:
         loop_var: role

--- a/tests/playbooks/integration.yaml
+++ b/tests/playbooks/integration.yaml
@@ -1,9 +1,27 @@
 - hosts: all
   tasks:
-    - name: Run integration test
+    - name: git config user.name
+      git_config:
+        name: user.name
+        scope: global
+        value: CaptTrews
+
+    - name: git config user.email
+      git_config:
+        name: user.email
+        scope: global
+        value: capttrews@gmail.com
+
+    - name: Bootstrap tox environment
       include_role:
         name: tox
       vars:
-        tox_extra_args: "-vv -- ansible-playbook -vv -e cli_namespace={{ collection_namespace }} -e cli_name={{ collection_name }} site-new.yaml"
+        tox_extra_args: "-vv --notest"
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/network_content_collector'].src_dir }}"
+
+    - name: Run integration tests
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_content_collector'].src_dir }}"
+        executable: /bin/bash
+      shell: "source .tox/venv/bin/activate; ansible-playbook -vv -e cli_namespace={{ collection_namespace }} -e cli_name={{ collection_name }} site-new.yaml"


### PR DESCRIPTION
This gives us a 2 stage option for git commit / git push.  For zuul, we
don't push directly, but use git pull-request.  This allows for NCC to
work properly locally still.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>