### PR TITLE
Add back github remotes for repos

### DIFF
--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -1,5 +1,15 @@
 - hosts: all
   tasks:
+    - name: Setup github remotes
+      args:
+        chdir: "{{ ansible_user_dir }}/src/github.com/ansible-network/ansible_collections.{{ collection_namespace }}.{{ collection_name }}"
+      shell: "git remote remove origin"
+
+    - name: Setup github remotes
+      args:
+        chdir: "{{ ansible_user_dir }}/src/github.com/ansible-network/ansible_collections.{{ collection_namespace }}.{{ collection_name }}"
+      shell: "git remote add origin https://github.com/ansible-network/ansible_collections.{{ collection_namespace }}.{{ collection_name }}"
+
     - name: Bootstrap tox environment
       include_role:
         name: tox


### PR DESCRIPTION
Zuul strips origin by default, so we need to add it back to create a PR.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>