### PR TITLE
Fixes for git commit

### DIFF
--- a/roles/commit_repo/tasks/main.yaml
+++ b/roles/commit_repo/tasks/main.yaml
@@ -4,6 +4,6 @@
     chdir: "{{ collection_parent }}"
 
 - name: Commit the repo
-  shell: "git commit --allow-empty -m 'based on ansible/ansible {{ ansible_sha }}'"
+  shell: "git commit -s --allow-empty -m '{{ ansible_commit_message }}'"
   args:
     chdir: "{{ collection_parent }}"

--- a/site-new.yaml
+++ b/site-new.yaml
@@ -3,6 +3,7 @@
     ansible_sha: "ansible/collections-sync"
     ansible_source_directory: "{{ ansible_user_dir }}/src/github.com/ansible/ansible"
     destination_directory: "{{ ansible_user_dir }}/src/github.com/ansible-network"
+    ansible_commit_message: "Updated from network content collector"
   tasks:
     - include_role:
         role: "{{ role }}"

--- a/site.yaml
+++ b/site.yaml
@@ -21,6 +21,10 @@
     set_fact:
       ansible_sha: "ansible_sha_{{ ansible_clone['after'] }}"
 
+  - name: Create git commit message
+    set_fact:
+      ansible_commit_message: "based on ansible/ansible {{ ansible_sha }}"
+
   - name: Run for each platform
     include: one_platform.yaml
     loop:


### PR DESCRIPTION
This allows zuul to override the commit message used, also starts to
signoff our commit messages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>