### PR TITLE
No longer allow empty commits

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,6 +6,8 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-network/network_content_collector
+    vars:
+      git_commit_opts: "-s"
 
 - job:
     name: propose-network-content-collector-base
@@ -79,6 +81,8 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-network/network_content_collector
+    vars:
+      git_commit_opts: "--allow-empty"
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 

--- a/roles/commit_repo/tasks/main.yaml
+++ b/roles/commit_repo/tasks/main.yaml
@@ -4,6 +4,6 @@
     chdir: "{{ collection_parent }}"
 
 - name: Commit the repo
-  shell: "git commit -s --allow-empty -m '{{ ansible_commit_message }}'"
+  shell: "git commit {{ git_commit_opts }} -m '{{ ansible_commit_message }}'"
   args:
     chdir: "{{ collection_parent }}"

--- a/site.yaml
+++ b/site.yaml
@@ -4,6 +4,7 @@
   vars:
     ansible_source_directory: /home/bthornto/github/network_content_collector/ansible
     destination_directory: /home/bthornto/github/ansible_collections
+    git_commit_opts: "--allow-empty"
   tasks:
   - name: Start fresh every time
     file:

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -22,4 +22,4 @@
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_content_collector'].src_dir }}"
         executable: /bin/bash
-      shell: "source .tox/venv/bin/activate; ansible-playbook -vv -e cli_namespace={{ collection_namespace }} -e cli_name={{ collection_name }} site-new.yaml"
+      shell: "source .tox/venv/bin/activate; ansible-playbook -vv -e git_commit_opts=\"{{ git_commit_opts }}\" -e cli_namespace={{ collection_namespace }} -e cli_name={{ collection_name }} site-new.yaml"


### PR DESCRIPTION
Now that we have automation in place, there isn't a need to push up
empty commits. We'll always ensure we have the latest code due to have
zuul runs the jobs now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>