### PR TITLE
Add netconf to target-prefixes

### DIFF
--- a/roles/network_integration_tests/tasks/main.yaml
+++ b/roles/network_integration_tests/tasks/main.yaml
@@ -5,9 +5,18 @@
     state: directory
   with_items: "{{ directories['test'] }}"
 
+- name: Set fact for target-prefixes
+  set_fact:
+    __target_prefix: "{{ collection_name }}"
+
+- name: Enable netconf target-prefixes
+  set_fact:
+    __target_prefix: "{{ __target_prefix }}\nnetconf"
+  when: collection_name in ["iosxr", "junos"]
+
 - name: Create target-prefixes.network for ansible-test
   copy:
-    content: "{{ collection_name }}"
+    content: "{{ __target_prefix }}"
     dest: "{{ collection_parent }}/test/integration/target-prefixes.network"
 
 - name: Build a list of the directories in the test directory


### PR DESCRIPTION
Both junos and iosxr also need netconf target-prefixes for ansible-test.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>