### PR TITLE
Revert "Also copy netconf test targets for iosxr / junos"

### DIFF
--- a/roles/network_integration_tests/tasks/main.yaml
+++ b/roles/network_integration_tests/tasks/main.yaml
@@ -19,21 +19,12 @@
     content: "{{ __target_prefix }}"
     dest: "{{ collection_parent }}/test/integration/target-prefixes.network"
 
-- name: Set fact for patterns
-  set_fact:
-    __test_patterns:
-      - "{{ collection_name }}_*"
-      - "prepare_{{ collection_name }}_tests"
-
-- name: Enable netconf patterns
-  set_fact:
-    __test_patterns: "{{ __test_patterns }} + ['netconf_*']"
-  when: collection_name in ["iosxr", "junos"]
-
 - name: Build a list of the directories in the test directory
   find:
     paths: "{{ ansible_source_directory }}/test/integration/targets"
-    patterns: "{{ __test_patterns }}"
+    patterns:
+    - "{{ collection_name }}_*"
+    - "prepare_{{ collection_name }}_tests"
     file_type: directory
   connection: local
   register: test_source_directories


### PR DESCRIPTION
We dont' actually need this, as network.netconf is now a collection.

This reverts commit 9f52deaae204fb6ea92343e6ad87e6491bc75874.