### PR TITLE
Add jobs for network.netconf collection

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -64,6 +64,16 @@
       proposal_project_src: ~/src/github.com/ansible-network/ansible_collections.network.cli
 
 - job:
+    name: propose-network-content-collector-network-netconf
+    parent: propose-network-content-collector-base
+    required-projects:
+      - name: github.com/ansible-network/ansible_collections.network.netconf
+    vars:
+      collection_namespace: network
+      collection_name: netconf
+      proposal_project_src: ~/src/github.com/ansible-network/ansible_collections.network.netconf
+
+- job:
     name: propose-network-content-collector-vyos-vyos
     parent: propose-network-content-collector-base
     required-projects:
@@ -132,6 +142,15 @@
       collection_name: cli
 
 - job:
+    name: network-content-collector-network-netconf
+    parent: network-content-collector-base
+    required-projects:
+      - name: github.com/ansible-network/ansible_collections.network.netconf
+    vars:
+      collection_namespace: network
+      collection_name: netconf
+
+- job:
     name: network-content-collector-vyos-vyos
     parent: network-content-collector-base
     required-projects:
@@ -148,6 +167,7 @@
         - network-content-collector-cisco-iosxr
         - network-content-collector-juniper-junos
         - network-content-collector-network-cli
+        - network-content-collector-network-netconf
         - network-content-collector-vyos-vyos
     gate:
       jobs:
@@ -156,6 +176,7 @@
         - network-content-collector-cisco-iosxr
         - network-content-collector-juniper-junos
         - network-content-collector-network-cli
+        - network-content-collector-network-netconf
         - network-content-collector-vyos-vyos
     post:
       jobs:
@@ -164,4 +185,5 @@
         - propose-network-content-collector-cisco-iosxr
         - propose-network-content-collector-juniper-junos
         - propose-network-content-collector-network-cli
+        - propose-network-content-collector-network-netconf
         - propose-network-content-collector-vyos-vyos


### PR DESCRIPTION
Now that network.netconf is setup in zuul, start migrating content.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>