### PR TITLE
Add junos / iosxr tests to netconf collection

### DIFF
--- a/roles/network_integration_tests/tasks/main.yaml
+++ b/roles/network_integration_tests/tasks/main.yaml
@@ -19,12 +19,21 @@
     content: "{{ __target_prefix }}"
     dest: "{{ collection_parent }}/test/integration/target-prefixes.network"
 
+- name: Set fact for patterns
+  set_fact:
+    __test_patterns:
+      - "{{ collection_name }}_*"
+      - "prepare_{{ collection_name }}_tests"
+
+- name: Enable netconf patterns
+  set_fact:
+    __test_patterns: "{{ __test_patterns }} + ['prepare_junos_tests', 'prepare_iosxr_tests']"
+  when: collection_name in ["netconf"]
+
 - name: Build a list of the directories in the test directory
   find:
     paths: "{{ ansible_source_directory }}/test/integration/targets"
-    patterns:
-    - "{{ collection_name }}_*"
-    - "prepare_{{ collection_name }}_tests"
+    patterns: "{{ __test_patterns }}"
     file_type: directory
   connection: local
   register: test_source_directories


### PR DESCRIPTION
These test files are needed to bring netconf collection testing online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>