### PR TITLE
Bump propose-network-content-collector-base timeout

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,6 +8,7 @@
       - name: github.com/ansible-network/network_content_collector
     vars:
       git_commit_opts: "-s"
+    timeout: 3600
 
 - job:
     name: propose-network-content-collector-base


### PR DESCRIPTION
Bump to 1hr timeout, to be same as our check / gate jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>