### PR TITLE
Revert "Switch to periodic-6hr pipeline"

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -200,7 +200,7 @@
         - network-content-collector-network-cli
         - network-content-collector-network-netconf
         - network-content-collector-vyos-vyos
-    periodic-6hr:
+    periodic:
       jobs:
         - propose-network-content-collector-arista-eos
         - propose-network-content-collector-cisco-ios


### PR DESCRIPTION
This was too agressive, we don't have the capacity to support this.

This reverts commit cb784c999deb679fa066892d200ca18328c2327b.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>